### PR TITLE
fix: fixing README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Instale as dependências do projeto:
 
   Ative o ambiente virtual
   ```sh 
-  source env/bin/activate
+  env/bin/activate
   ```
 
 </details>


### PR DESCRIPTION
In Windows, there is no `source` command to activate a virtual environment.